### PR TITLE
Hdc/update speed and interrupt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use embedded_hal::can::Error as CanError;
 
-use crate::{CanSpeed, McpSpeed};
+use crate::{regs::TxbCtrl, CanSpeed, McpSpeed};
 
 pub type Result<T, SPI, HAL> = core::result::Result<T, Error<SPI, HAL>>;
 
@@ -15,7 +15,7 @@ pub enum Error<SPI: Debug, HAL: Debug> {
     /// Tx buffers are full and therefore cannot send another message.
     TxBusy,
     /// Failed to send a message.
-    TxFailed,
+    TxFailed(TxbCtrl),
     /// There was no message to be received in the Rx buffers.
     NoMessage,
     /// Received an invalid frame ID.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,9 @@ where
                 .with_merre(true),
         )?;
 
+        // Enable interrupts for RX0BF and RX1BF
+        self.write_registers(Register::BFPCTRL, &[0b0000_1111])?;
+
         // Receive all messages that have a standard or extended identifier. Set RXF0 up
         // for RXB0 and RXF1 up for RXB1.
         self.modify_register(
@@ -433,7 +436,7 @@ where
         // Check for any errors.
         let ctrl = self.read_txb_ctrl(&buf)?;
         if ctrl.abtf() || ctrl.mloa() || ctrl.txerr() {
-            Err(Error::TxFailed)
+            Err(Error::TxFailed(ctrl))
         } else {
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub enum CanSpeed {
 pub enum McpSpeed {
     MHz8,
     MHz16,
+    MHz20,
 }
 
 /// Settings used to initialize the MCP2515.
@@ -103,8 +104,8 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             mode: OpMode::Normal,
-            can_speed: CanSpeed::Kbps100,
-            mcp_speed: McpSpeed::MHz16,
+            can_speed: CanSpeed::Kbps1000,
+            mcp_speed: McpSpeed::MHz20,
             clkout_en: false,
         }
     }
@@ -300,6 +301,8 @@ where
             (McpSpeed::MHz16, CanSpeed::Kbps250) => (0x41, 0xE5, 0x83),
             (McpSpeed::MHz16, CanSpeed::Kbps500) => (0x40, 0xE5, 0x83),
             (McpSpeed::MHz16, CanSpeed::Kbps1000) => (0x00, 0xCA, 0x81),
+            (McpSpeed::MHz20, CanSpeed::Kbps1000) => (0x00, 0xD9, 0x82),
+
             _ => return Err(Error::InvalidConfiguration(can_speed, mcp_speed)),
         };
         let mut cfg3 = Cnf3::from_bytes([cfg3]);

--- a/src/regs.rs
+++ b/src/regs.rs
@@ -21,6 +21,7 @@ pub enum Register {
     RXF2SIDL = 0x09,
     RXF2EID8 = 0x0A,
     RXF2EID0 = 0x0B,
+    BFPCTRL = 0x0C,
     CANSTAT = 0x0E,
     CANCTRL = 0x0F,
     RXF3SIDH = 0x10,


### PR DESCRIPTION
## Why are we making these changes?
Update to work with 20mhz crystal on hyphen boards

## How did you test these changes?
 Tested locally with new v2 ducs.

## What changed?
- add mcp_speed: McpSpeed::MHz20
- enable rx buffer interrupts
- add more info to error message